### PR TITLE
Fixes lost SoC precision due to integer division

### DIFF
--- a/src/model_gauge.cpp
+++ b/src/model_gauge.cpp
@@ -140,11 +140,11 @@ float ModelGauge::get_soc()
     read_word(0x04, SOC_1, SOC_2); 
     if(_config.bits == 18) 
     { 
-        SOC_percent = ((SOC_1 << 8) + SOC_2) / 256; 
+        SOC_percent = ((SOC_1 << 8) + SOC_2) / 256.0f;
     } 
     else if(_config.bits == 19) 
     { 
-        SOC_percent = ((SOC_1 << 8) + SOC_2) / 512; 
+        SOC_percent = ((SOC_1 << 8) + SOC_2) / 512.0f;
     }
     return SOC_percent;
 }


### PR DESCRIPTION
While working on a [related feature for Device OS that sets the custom model bits to 18 or 19](https://github.com/particle-iot/device-os/pull/2401), I noticed that the system `FuelGauge::getSoC()` function was returning 93.70% while the `ModelGauge::get_soc()` was returning 93.00%.

This was due to integer division.